### PR TITLE
Setting up Build Pipeline

### DIFF
--- a/.azure/azure-pipelines.yaml
+++ b/.azure/azure-pipelines.yaml
@@ -17,36 +17,11 @@ steps:
     workingDirectory: '$(System.DefaultWorkingDirectory)'
 
 - task: Go@0
-  displayName: 'Install Test Dependencies'
-  inputs:
-    command: 'get'
-    arguments: 'github.com/jstemmer/go-junit-report github.com/axw/gocov/gocov github.com/AlekSi/gocov-xml golang.org/x/tools/cmd/cover'
-
-- task: Go@0
   displayName: 'Building Abstrakt'
   inputs:
     command: build
     arguments: '-o "$(Build.Repository.Name)"'
     workingDirectory: '$(System.DefaultWorkingDirectory)'
-
-- task: Bash@3
-  displayName: 'Run Unit Tests'
-  inputs:
-    filePath: '$(Build.Repository.LocalPath)/.azure/test.sh'
-
-- task: PublishTestResults@2
-  displayName: 'test cluster'
-  inputs:
-    testRunner: JUnit
-    testResultsFiles: $(System.DefaultWorkingDirectory)/**/report.xml
-    failTaskOnFailedTests: true
-
-- task: PublishCodeCoverageResults@1
-  inputs:
-    codeCoverageTool: Cobertura 
-    summaryFileLocation: $(System.DefaultWorkingDirectory)/**/coverage.xml
-    reportDirectory: $(System.DefaultWorkingDirectory)/**/coverage
-    failIfCoverageEmpty: true
 
 - task: ArchiveFiles@2
   displayName: 'Archive Files'

--- a/.azure/test.sh
+++ b/.azure/test.sh
@@ -1,3 +1,0 @@
-go test -coverprofile=coverage.txt -covermode count 2>&1 | tee testlogs.txt
-go-junit-report < testlogs.txt > report.xml
-go tool cover -html=coverage.txt -o cover.html


### PR DESCRIPTION
This PR introduces the `.azure/azure-pipelines.yaml` to build Abstrakt and publish the results as a build artifact.

**What this PR does / why we need it**:
Builds project when creating a PR and when committing to `master`.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests